### PR TITLE
Corrected paths, added updating sources on provisioning file for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Vagrant setup for building otto modes
 # Usage
 Once the vagrant instance is up and running and you have ssh'ed in
 
-    cd /stak/sdk/otto-sdk
+    cd /stak/sdk/otto-runner
     make -j4 # change the number to however many tasks you want to run in parallel.
 
-And the otto-sdk is built.
+And the otto-runner is built.
 
 For instructions on building and running otto-menu and related libraries, please refer to the appropriate repository.

--- a/fetch-modes.sh
+++ b/fetch-modes.sh
@@ -10,6 +10,6 @@ function fetch_repo {
   fi
 }
 
-fetch_repo otto-sdk
+fetch_repo otto-runner
 fetch_repo otto-menu
 fetch_repo otto-gif-mode

--- a/provisioning-scripts/guest-003-install-dependencies.sh
+++ b/provisioning-scripts/guest-003-install-dependencies.sh
@@ -35,6 +35,8 @@ fi
 
 # get standard build tools
 log "Installing required packages for building..."
+apt-get update 2>&1 > /dev/null
+  || error "Error. Could not update sources!"
 apt-get install -y git make cmake python-pip 2>&1 > /dev/null \
   || error "Error getting required packages!"
 apt-get -y autoremove 2>&1 > /dev/null

--- a/provisioning-scripts/guest-003-install-dependencies.sh
+++ b/provisioning-scripts/guest-003-install-dependencies.sh
@@ -35,7 +35,7 @@ fi
 
 # get standard build tools
 log "Installing required packages for building..."
-apt-get update 2>&1 > /dev/null
+apt-get update 2>&1 > /dev/null \
   || error "Error. Could not update sources!"
 apt-get install -y git make cmake python-pip 2>&1 > /dev/null \
   || error "Error getting required packages!"

--- a/provisioning-scripts/guest-007-install-libbcm2835.sh
+++ b/provisioning-scripts/guest-007-install-libbcm2835.sh
@@ -60,8 +60,8 @@ if [ ! -f "${BCM2835_DIR}/.build.succeeded" ]; then
     rm $SOURCES/bcm2835-${BCM2835_VERSION}.tar.gz 2>&1 > /dev/null
   fi
   log "Building libbcm2835..."
-  cp ${BCM2835_DIR}/src/bcm2835.c /stak/sdk/otto-sdk/lib/bcm2835.c
-  cp ${BCM2835_DIR}/src/bcm2835.h /stak/sdk/otto-sdk/lib/bcm2835.h
+  cp ${BCM2835_DIR}/src/bcm2835.c /stak/sdk/otto-runner/lib/bcm2835.c
+  cp ${BCM2835_DIR}/src/bcm2835.h /stak/sdk/otto-runner/lib/bcm2835.h
   #   ${TARGET}-gcc \
   #                 -o ${BCM2835_DIR}/src/bcm2835.o \
   #                 -I${BCM2835_DIR}/src \

--- a/provisioning-scripts/host-001-install-otto-repos.sh
+++ b/provisioning-scripts/host-001-install-otto-repos.sh
@@ -39,7 +39,7 @@ if [ ! -d "otto-menu" ]; then
 fi
 
 
-if [ ! -d "otto-sdk" ]; then
-  git clone -b cross-toolchain-transition git@github.com:NextThingCo/otto-sdk.git otto-sdk \
-      || error "Could not download otto-sdk"
+if [ ! -d "otto-runner" ]; then
+  git clone -b cross-toolchain-transition git@github.com:NextThingCo/otto-runner.git otto-runner \
+      || error "Could not download otto-runner"
 fi


### PR DESCRIPTION
I guess this was forgotten when otto-sdk was renamed to otto-runner. Threw an error or led to missing dependencies when setting up the vagrant box.